### PR TITLE
or-and-function.kt

### DIFF
--- a/Kotlin/or-and-function.kt
+++ b/Kotlin/or-and-function.kt
@@ -1,0 +1,11 @@
+fun main(args: Array<String>) {
+    val a = true
+    val b = false
+    var result: Boolean
+
+    result = a or b // a.or(b)
+    println("result = $result")
+
+    result = a and b // a.and(b)
+    println("result = $result")
+}


### PR DESCRIPTION
In this program, a or b instead of a.or(b), and a and b instead of a.and(b) is used. It was possible because these two functions support infix notation.